### PR TITLE
Fix GCS param path and validate downloads

### DIFF
--- a/src/components/train_lstm/main.py
+++ b/src/components/train_lstm/main.py
@@ -74,7 +74,11 @@ def train_final_model(
     # Descarga de artefactos necesarios a un directorio temporal
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-        loc_params = gcs_utils.download_gcs_file(params_path, tmp_path)
+        try:
+            loc_params = gcs_utils.download_gcs_file(params_path, tmp_path)
+        except FileNotFoundError:
+            logger.error("No se encontró el archivo de parámetros en GCS: %s", params_path)
+            raise
         hp = json.loads(loc_params.read_text())
         
         loc_feat = gcs_utils.download_gcs_file(features_gcs_path, tmp_path)

--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -122,7 +122,7 @@ def trading_pipeline_v5(
             region=constants.REGION,
             pair=pair,
             timeframe=timeframe,
-            params_file=optimize_logic_task.outputs['best_params_dir'],
+            params_file=f"{optimize_logic_task.outputs['best_params_dir']}/{pair}/best_params.json",
             features_gcs_path=prepare_opt_data_task.outputs["prepared_data_path"],
             output_gcs_base_dir=constants.LSTM_MODELS_PATH,
             vertex_training_image_uri=args.common_image_uri,

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -109,7 +109,8 @@ class TestGcsUtils:
         mock_blob = MagicMock()
         mock_gcs_client.return_value.bucket.return_value = mock_bucket
         mock_bucket.blob.return_value = mock_blob
-        
+        mock_blob.exists.return_value = True
+
         gcs_uri = "gs://my-test-bucket/path/to/download.txt"
         destination_dir = tmp_path
 
@@ -119,6 +120,7 @@ class TestGcsUtils:
         # Aserciones
         mock_gcs_client.return_value.bucket.assert_called_once_with("my-test-bucket")
         mock_bucket.blob.assert_called_once_with("path/to/download.txt")
+        mock_blob.exists.assert_called_once()
         expected_local_path = destination_dir / "download.txt"
         mock_blob.download_to_filename.assert_called_once_with(expected_local_path)
         assert result_path == expected_local_path


### PR DESCRIPTION
## Summary
- pass full path to best params file when launching train LSTM
- check blob existence when downloading from GCS
- log missing params file during training
- update unit tests for the existence check

## Testing
- `pytest -q` *(fails: ImportError and AttributeError in component tests)*

------
https://chatgpt.com/codex/tasks/task_e_685249fb58a88329bf6a2d27f7313934