### PR TITLE
Fix parameter passing in pipeline and include indicator params

### DIFF
--- a/src/components/optimize_trading_logic/task.py
+++ b/src/components/optimize_trading_logic/task.py
@@ -131,6 +131,10 @@ def run_logic_optimization(
         with open(local_arch_path, 'r') as f:
             arch_params = json.load(f)
 
+        # --- CORRECCIÓN: asegurar que los parámetros de indicadores
+        # fijos acompañen a los de arquitectura para evitar KeyError posteriores.
+        arch_params.update(constants.DUMMY_INDICATOR_PARAMS)
+
         df_raw = df_full[df_full['pair'] == pair] if 'pair' in df_full.columns else df_full
         df_raw["timestamp"] = pd.to_datetime(df_raw["timestamp"], unit="ms", errors="coerce")
 

--- a/src/shared/indicators.py
+++ b/src/shared/indicators.py
@@ -18,6 +18,12 @@ from typing import Dict, Tuple, Callable, List
 import logging
 
 import pandas as pd
+import numpy as np
+
+# --- CORRECCIÓN: algunas versiones recientes de NumPy no exponen la
+# constante `NaN` que espera `pandas_ta`. Se crea un alias si es necesario.
+if not hasattr(np, "NaN"):
+    np.NaN = np.nan
 
 try:
     import pandas_ta as ta


### PR DESCRIPTION
## Summary
- build artifact paths with `dsl.Concat` so KFP resolves them correctly
- merge fixed indicator hyperparameters when optimizing trading logic
- patch indicators module for NumPy 2 compatibility

## Testing
- `pytest -q` *(fails: data_ingestion and other tests require cloud credentials)*

------
https://chatgpt.com/codex/tasks/task_e_685258384750832991d64bd75f086244