### PR TITLE
Add KFP version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ pip install .
 This installs the `src` package along with all required third party
 libraries.
 
+> **Note**
+> The pipeline requires Kubeflow Pipelines SDK **2.0** or newer in order to use
+> `dsl.Concat`.  If you encounter import errors, ensure that `kfp>=2.13.0` is
+> installed.
+
 ## Running tests
 
 After installing the package you can run the unit tests with `pytest`:

--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -10,11 +10,20 @@ from pathlib import Path
 
 import google.cloud.aiplatform as aip
 from kfp import compiler, dsl
+from packaging import version
+import kfp
 # NOTE: Use the DSL helper to concatenate dynamic strings when passing
 # arguments to components. `ConcatPlaceholder` is intended for component
 # definitions and causes type errors when used directly in a pipeline.
 from kfp.dsl import Concat
 from kfp.components import load_component_from_text
+
+# Verificar que la versión de KFP sea compatible con `dsl.Concat`.
+if version.parse(kfp.__version__) < version.parse("2.0.0"):
+    raise ImportError(
+        f"KFP>=2.0.0 es requerido para usar dsl.Concat; versión detectada: {kfp.__version__}. "
+        "Actualiza con 'pip install --upgrade \"kfp>=2.13.0\"'."
+    )
 
 # AJUSTE: Se asegura que 'constants' sea la única fuente de configuración.
 from src.shared import constants


### PR DESCRIPTION
## Summary
- ensure KFP version >=2.0 to use `dsl.Concat`
- document the requirement in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install -r requirements.txt` *(fails: pycairo dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852613d8dd083299969c1cb1a0c2f6d