### PR TITLE
Fix pipeline annotation parsing

### DIFF
--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -8,7 +8,6 @@ Implementa una gestión de rutas centralizada y robusta.
       correcta sin romper versiones antiguas (<2.0).
 """
 
-from __future__ import annotations
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Imports estándar


### PR DESCRIPTION
## Summary
- adjust `main.py` to drop postponed evaluation of annotations

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68528ee3745c83299052c200e8793536