### PR TITLE
Fix KFP 2.x Concat import

### DIFF
--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -37,7 +37,11 @@ from kfp.components import load_component_from_text
 if version.parse(kfp.__version__) < version.parse("2.0.0"):
     from kfp.dsl import Concat  # type: ignore  # disponible en KFP 1.x
 else:
-    from kfp.dsl import ConcatPlaceholder as Concat  # type: ignore
+    from kfp.dsl import ConcatPlaceholder as _ConcatPlaceholder  # type: ignore
+
+    def Concat(*args):  # type: ignore
+        """Shim para KFP >= 2.0, acepta *args como en versiones previas."""
+        return _ConcatPlaceholder(list(args))
 
 # ───────────────────────────────────────────────────────────────────────────────
 # Módulos internos


### PR DESCRIPTION
## Summary
- support KFP 2.x by wrapping `ConcatPlaceholder`

## Testing
- `pytest -q` *(fails: DefaultCredentialsError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6852e0cb64908329a6f05e6b015166ec