### PR TITLE
Fix EarlyStopping with validation

### DIFF
--- a/src/components/train_lstm/main.py
+++ b/src/components/train_lstm/main.py
@@ -108,9 +108,19 @@ def train_final_model(
         logger.info("Dataset final para entrenamiento: X=%s", X_seq.shape)
 
         model = make_model(X_seq.shape[1:], hp["lr"], hp["dr"], hp["filt"], hp["units"], hp["heads"])
-        model.fit(X_seq, np.vstack([y_up, y_dn]).T, epochs=60, batch_size=128,
-                  callbacks=[callbacks.EarlyStopping(patience=5, restore_best_weights=True)],
-                  verbose=1)
+        model.fit(
+            X_seq,
+            np.vstack([y_up, y_dn]).T,
+            epochs=60,
+            batch_size=128,
+            validation_split=0.2,
+            callbacks=[
+                callbacks.EarlyStopping(
+                    monitor="val_loss", patience=5, restore_best_weights=True
+                )
+            ],
+            verbose=1,
+        )
 
         # Guardar artefactos localmente antes de subirlos.
         loc_artifacts_dir = tmp_path / "artifacts"


### PR DESCRIPTION
## Summary
- split training data for validation
- monitor `val_loss` in early stopping

## Testing
- `pytest -q` *(fails: AttributeError: module 'src.components.train_lstm_launcher' has no attribute 'task')*

------
https://chatgpt.com/codex/tasks/task_e_68545a9185e88329981514d845c891e7