### PR TITLE
Handle missing indicator params in filter trainer

### DIFF
--- a/src/components/train_filter_model/task.py
+++ b/src/components/train_filter_model/task.py
@@ -136,6 +136,14 @@ def run_filter_training(
         scaler = joblib.load(scaler_path)
         hp = json.loads(params_path.read_text())
 
+        # 🔹 Asegurar que el JSON contenga los hiperparámetros de indicadores
+        # necesarios para `build_indicators`.  Algunos archivos antiguos podían
+        # carecer de estas claves, lo que provocaba un ``KeyError`` al intentar
+        # generar los indicadores.  Para garantizar robustez, se completan con
+        # los valores por defecto definidos en ``constants.DUMMY_INDICATOR_PARAMS``.
+        for k, v in constants.DUMMY_INDICATOR_PARAMS.items():
+            hp.setdefault(k, v)
+
     # 2. Generar el dataset de entrenamiento para el filtro
     local_features = gcs_utils.ensure_gcs_path_and_get_local(features_path)
     df_raw = pd.read_parquet(local_features)


### PR DESCRIPTION
## Summary
- guard against missing indicator hyperparameters when loading `params.json` in `train_filter_model`

## Testing
- `pytest -q` *(fails: AttributeError: module 'src.components.data_ingestion' has no attribute 'task')*

------
https://chatgpt.com/codex/tasks/task_e_6854a14fad508329b8f28fe6f82c3060