### PR TITLE
Fix custom metric restoration in filter training

### DIFF
--- a/src/components/train_filter_model/task.py
+++ b/src/components/train_filter_model/task.py
@@ -157,7 +157,11 @@ def run_filter_training(
         model_path = gcs_utils.download_gcs_file(f"{lstm_model_dir}/model.keras", tmp)
         scaler_path = gcs_utils.download_gcs_file(f"{lstm_model_dir}/scaler.pkl", tmp)
         params_path = gcs_utils.download_gcs_file(f"{lstm_model_dir}/params.json", tmp)
-        lstm_model = models.load_model(model_path, compile=False)
+        lstm_model = models.load_model(
+            model_path,
+            compile=False,
+            custom_objects={"Recall": tf.keras.metrics.Recall},
+        )
         scaler = joblib.load(scaler_path)
         hp = json.loads(params_path.read_text())
 


### PR DESCRIPTION
## Summary
- ensure Keras model loader knows about custom Recall metric

## Testing
- `pytest -q` *(fails: module 'src.components.data_ingestion' has no attribute 'task', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6854e7f3a1948329abfbf72c2fee6cc0