### PR TITLE
Fix service account for filter training step

### DIFF
--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -159,6 +159,9 @@ def trading_pipeline_v5(
             timeframe=timeframe,
             output_gcs_base_dir=constants.FILTER_MODELS_PATH,
         )
+        train_filter_task.set_service_account(
+            constants.VERTEX_LSTM_SERVICE_ACCOUNT
+        )
         train_filter_task.set_accelerator_type("NVIDIA_TESLA_T4")
         train_filter_task.set_accelerator_limit(1)
 


### PR DESCRIPTION
## Summary
- set Vertex AI service account for the `train_filter_model` task

## Testing
- `pip install -r requirements.txt` *(fails: error building pycairo - missing system deps)*

------
https://chatgpt.com/codex/tasks/task_e_68550899a59883298dc8caa0f08d959d